### PR TITLE
Runtime EVM call access

### DIFF
--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -66,7 +66,7 @@ pub mod runner;
 mod tests;
 
 use frame_support::{
-	dispatch::{DispatchResultWithPostInfo, Pays, PostDispatchInfo, DispatchErrorWithPostInfo},
+	dispatch::{DispatchErrorWithPostInfo, DispatchResultWithPostInfo, Pays, PostDispatchInfo},
 	traits::{
 		tokens::fungible::Inspect, Currency, ExistenceRequirement, FindAuthor, Get, Imbalance,
 		OnUnbalanced, SignedImbalance, WithdrawReasons,
@@ -75,10 +75,10 @@ use frame_support::{
 };
 use frame_system::RawOrigin;
 use impl_trait_for_tuples::impl_for_tuples;
-use sp_core::{Hasher, H160, H256, U256, RuntimeDebug};
+use sp_core::{Hasher, RuntimeDebug, H160, H256, U256};
 use sp_runtime::{
 	traits::{BadOrigin, Saturating, UniqueSaturatedInto, Zero},
-	AccountId32
+	AccountId32,
 };
 use sp_std::{cmp::min, vec::Vec};
 
@@ -222,7 +222,7 @@ pub mod pallet {
 				true,
 			) {
 				Ok(result) => Ok(result.info),
-				Err(e) => Err(e)
+				Err(e) => Err(e),
 			}
 		}
 
@@ -788,15 +788,15 @@ impl<T: Config> Pallet<T> {
 		if is_free {
 			T::FreeCalls::on_sent_free_call(&source);
 		}
-		Ok(PostDispatchInfoWithValue { 
-			info: PostDispatchInfo { 
+		Ok(PostDispatchInfoWithValue {
+			info: PostDispatchInfo {
 				actual_weight: Some(T::GasWeightMapping::gas_to_weight(
 					info.used_gas.unique_saturated_into(),
 					true,
-				)), 
+				)),
 				pays_fee: Pays::No,
-			}, 
-			value: info.value, 
+			},
+			value: info.value,
 			exit_reason: info.exit_reason,
 		})
 	}
@@ -986,7 +986,7 @@ pub trait EvmCall {
 		target: H160,
 		input: Vec<u8>,
 		gas_limit: u64,
-		is_transactional: bool
+		is_transactional: bool,
 	) -> Result<PostDispatchInfoWithValue, DispatchErrorWithPostInfo>;
 }
 
@@ -1008,7 +1008,7 @@ impl<T: Config> EvmCall for Pallet<T> {
 			None,
 			None,
 			vec![],
-            is_transactional,
+			is_transactional,
 		)
 	}
 }


### PR DESCRIPTION
* add `EvmCall` trait to avoid tight coupling and signed origin requirements
* refactor call dispatchable contents into `do_call`
* new struct `PostDispatchInfoWithValue` to return value and exit reason (call can be Ok even if it reverts) for trait impl only

We should think carefully about safety of removing the origin requirement.

We should also think about how to handle gas:
- continue using minimum gas price or expose to client?
- make use of `FreeCalls`? (looks like it was removed in latest version)
- gas limit estimation?